### PR TITLE
Fix typo in JS function name

### DIFF
--- a/src/Audio/WebAudio/AudioParam.js
+++ b/src/Audio/WebAudio/AudioParam.js
@@ -35,7 +35,7 @@ exports.linearRampToValueAtTime = function(value) {
   return function(endTime) {
     return function(param) {
       return function() {
-        param.lienarRampToValueAtTime(value, endTime);
+        param.linearRampToValueAtTime(value, endTime);
       };
     };
   };


### PR DESCRIPTION
`lienarRampToValueAtTime` should be `linearRampToValueAtTime`